### PR TITLE
scrivenger_list needs to be in applications as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,14 @@ def deps do
 end
 ```
 
+Also make sure to add `:scrivener_list` to your `applications`:
 
+```elixir
+  def application do
+    [mod: {MyApp, []},
+     applications: [:scrivener_list]]
+  end
+```
 ## Tests
 
 ```shell


### PR DESCRIPTION
I followed the install instructions in the README during deployment I noticed that this has to be added as well.