### PR TITLE
Fix for links in hex docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+-   Fix broken links on hex docs
+
 ## v2.0.0
 
 -   Relax the requirements for `scrivener_ecto` to allow 1.x and 2.x

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Scrivener.List [![Build Status](https://travis-ci.org/stephenmoloney/scrivener_list.svg)](https://travis-ci.org/stephenmoloney/scrivener_list) [![Hex Version](http://img.shields.io/hexpm/v/scrivener_list.svg?style=flat)](https://hex.pm/packages/scrivener_list) [![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg?style=flat)](https://hexdocs.pm/scrivener_list)
+# Scrivener.List
+[![Build Status](https://travis-ci.org/stephenmoloney/scrivener_list.svg)](https://travis-ci.org/stephenmoloney/scrivener_list)
+[![Hex Version](http://img.shields.io/hexpm/v/scrivener_list.svg?style=flat)](https://hex.pm/packages/scrivener_list)
+[![Hex docs](http://img.shields.io/badge/hex.pm-docs-green.svg?style=flat)](https://hexdocs.pm/scrivener_list)
 
 [Scrivener.List](https://hex.pm/packages/scrivener_list) is a Scrivener compatible extension that
 allows the pagination of a list of elements.

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Scrivener.List.Mixfile do
   use Mix.Project
-  @version "2.0.0"
+  @version "2.0.1"
   @name "Scrivener.List"
   @source_url "https://github.com/stephenmoloney/scrivener_list"
   @homepage_url "https://hexdocs.pm/scrivener_list"
@@ -59,7 +59,7 @@ defmodule Scrivener.List.Mixfile do
 
   defp docs do
     [
-      main: "README.md",
+      main: "readme",
       extra_section: "Scrivener.List",
       extras: [
         "README.md": [path: "README.md", title: "Scrivener.List"]


### PR DESCRIPTION
What does this commit/MR/PR do ?

- Fix for links in hex docs

Why is this commit/MR/PR needed ?

- Hex docs links were broken