### PR TITLE
Update mix.exs to allow `scrivener_ecto ~> 3.0`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Scrivener.List.Mixfile do
 
   defp deps() do
     [
-      {:scrivener_ecto, "~> 1.0 or ~> 2.0"},
+      {:scrivener_ecto, "~> 1.0 or ~> 2.0 or ~> 3.0"},
 
       # dev/test
       {:earmark, "~> 1.3", only: :dev, runtime: false},


### PR DESCRIPTION
Recently, `ecto` made some breaking changes with `3.12.0` and `scrivener_ecto` was updated accordingly (see [here](https://github.com/mojotech/scrivener_ecto/pull/105)). The `scrivener_ecto` package was also bumped up to a new major version `3.0`, though it's a backwards-compatible change with respect to `scrivener_list` (see the diff [here](https://diff.hex.pm/diff/scrivener_ecto/2.7.1..3.0.0)). In other words, it is safe for this package to now support `scrivener_ecto` at `~> 1.0 or ~> 2.0 or ~> 3.0`, which is what this PR does.

This change is required to allow using `scrivener_ecto ~> 3.0` and `scrivener_list` in the same project, otherwise a dependency conflict is raised.