### PR TITLE
Explicitly depend on :scrivener

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Scrivener.List.Mixfile do
 
   defp deps() do
     [
+      {:scrivener, "~> 2.7"},
       {:scrivener_ecto, "~> 3.0 or ~> 2.7", optional: true},
 
       # dev/test


### PR DESCRIPTION
Since Elixir v 1.19 `scrivener_list` doesn't compile for apps which don't specify `:scrivener_ecto` as dependency (but include `:scrivener_html` for example).
 
```
==> scrivener_list
Compiling 1 file (.ex)

== Compilation error in file lib/scrivener/paginater/list.ex ==
** (ArgumentError) could not load module Scrivener.Paginater due to reason :nofile
    (elixir 1.19.4) lib/protocol.ex:331: Protocol.assert_protocol!/2
    lib/scrivener/paginater/list.ex:1: (file)
    (elixir 1.19.4) lib/kernel/parallel_compiler.ex:529: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
could not compile dependency :scrivener_list, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile scrivener_list --force", update it with "mix deps.update scrivener_list" or clean it with "mix deps.clean scrivener_list"
```

 Adding `:scrivener` explicitly as a dependency to `:scrivener_list`  fixes that.